### PR TITLE
Add Docker environment & web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Technical Report 2022.
 
 ![A sample 2 seconds moment.](https://github.com/googlestaging/frame-interpolation/blob/main/moment.gif)
 
+## Web Demo
+
+Try the interpolation model with the replicate web demo at 
+[![Replicate](https://replicate.com/google-research/frame-interpolation/badge)](https://replicate.com/google-research/frame-interpolation)
+
 ## Installation
 
 *   Get Frame Interpolation source codes

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,23 @@
+build:
+  gpu: true
+  cuda: "11.2"
+  python_version: "3.8"
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+  python_packages:
+    - "ipython==7.30.1"
+    - "tensorflow-gpu==2.8.0"
+    - "tensorflow-datasets==4.4.0"
+    - "tensorflow-addons==0.15.0"
+    - "absl-py==0.12.0"
+    - "gin-config==0.5.0"
+    - "parameterized==0.8.1"
+    - "mediapy==1.0.3"
+    - "scikit-image==0.19.1"
+    - "apache-beam==2.34.0"
+  run:
+    - apt-get update && apt-get install -y software-properties-common
+    - apt-get install ffmpeg -y
+
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,73 @@
+import os
+from pathlib import Path
+import numpy as np
+import tempfile
+import mediapy
+import cog
+
+from eval import interpolator, util
+
+
+class Predictor(cog.Predictor):
+    def setup(self):
+        import tensorflow as tf
+        print("Num GPUs Available: ", len(tf.config.list_physical_devices('GPU')))
+        self.interpolator = interpolator.Interpolator("pretrained_models/film_net/Style/saved_model", None)
+
+        # Batched time.
+        self.batch_dt = np.full(shape=(1,), fill_value=0.5, dtype=np.float32)
+
+    @cog.input(
+        "frame1",
+        type=Path,
+        help="The first input frame",
+    )
+    @cog.input(
+        "frame2",
+        type=Path,
+        help="The second input frame",
+    )
+    @cog.input(
+        "times_to_interpolate",
+        type=int,
+        default=1,
+        min=1,
+        max=8,
+        help="Controls the number of times the frame interpolator is invoked If set to 1, the output will be the "
+             "sub-frame at t=0.5; when set to > 1, the output will be the interpolation video with "
+             "(2^times_to_interpolate + 1) frames, fps of 30.",
+    )
+    def predict(self, frame1, frame2, times_to_interpolate):
+        INPUT_EXT = ['.png', '.jpg']
+        assert os.path.splitext(str(frame1))[-1] in INPUT_EXT and os.path.splitext(str(frame2))[-1] in INPUT_EXT, \
+            "Please provide png or jpg images."
+        
+        if times_to_interpolate == 1:
+            # First batched image.
+            image_1 = util.read_image(str(frame1))
+            image_batch_1 = np.expand_dims(image_1, axis=0)
+    
+            # Second batched image.
+            image_2 = util.read_image(str(frame2))
+            image_batch_2 = np.expand_dims(image_2, axis=0)
+    
+            # Invoke the model once.
+            
+            mid_frame = self.interpolator.interpolate(image_batch_1, image_batch_2, self.batch_dt)[0]
+            out_path = Path(tempfile.mkdtemp()) / "out.png"
+            util.write_image(str(out_path), mid_frame)
+            return out_path
+
+
+        input_frames = [str(frame1), str(frame2)]
+
+        frames = list(
+            util.interpolate_recursively_from_files(
+                input_frames, times_to_interpolate, self.interpolator))
+        print('Interpolated frames generated, saving now as output video.')
+
+        ffmpeg_path = util.get_ffmpeg_path()
+        mediapy.set_ffmpeg(ffmpeg_path)
+        out_path = Path(tempfile.mkdtemp()) / "out.mp4"
+        mediapy.write_video(str(out_path), frames, fps=30)
+        return out_path


### PR DESCRIPTION
This pull request makes it possible to run your model inside a Docker environment, which makes it easier for other people to run it.  We're using an open source tool called [Cog](https://github.com/replicate/cog) to make this process easier.

This also means we can make a web page where other people can try out your model! View it here: https://replicate.com/google-research/frame-interpolation. You can find the docker file under the tab ‘run model with docker’. 

We have added some examples to the page, but do claim the page so you can own the page, customise the Example gallery as you like, push any future update to the web demo, and we'll feature it on our website and tweet about it too. You can find the 'Claim this model' button on the top of the page. Any member of the google-researach organization on GitHub can claim the model ~ 

In case you're wondering who I am, I'm from [Replicate](https://replicate.com/home), where we're trying to make machine learning reproducible. We got frustrated that we couldn't run all the really interesting ML work being done. So, we're going round implementing models we like. 😊